### PR TITLE
fix(ci): publish xion-types to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-ts.yaml
+++ b/.github/workflows/publish-ts.yaml
@@ -16,7 +16,6 @@ on:
 env:
   NODE_VERSION: "20"
   PNPM_VERSION: "9"
-  REGISTRY_URL: "https://registry.npmjs.org"
 
 jobs:
   build:
@@ -108,14 +107,14 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: ${{ env.REGISTRY_URL }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         with:
           version: ${{ env.PNPM_VERSION }}
 
+      - name: Upgrade npm for OIDC trusted publishing (requires >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: bash scripts/ci/ts.sh "${{ inputs.release_tag }}"

--- a/.github/workflows/publish-ts.yaml
+++ b/.github/workflows/publish-ts.yaml
@@ -114,7 +114,7 @@ jobs:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Upgrade npm for OIDC trusted publishing (requires >= 11.5.1)
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Publish
         run: bash scripts/ci/ts.sh "${{ inputs.release_tag }}"

--- a/.github/workflows/publish-ts.yaml
+++ b/.github/workflows/publish-ts.yaml
@@ -15,6 +15,8 @@ on:
 
 env:
   NODE_VERSION: "20"
+  # npm OIDC trusted publishing requires Node >= 22.14.0 (publish job only).
+  PUBLISH_NODE_VERSION: "22"
   PNPM_VERSION: "9"
 
 jobs:
@@ -106,7 +108,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ env.PUBLISH_NODE_VERSION }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,9 @@ jobs:
   publish-ts:
     name: TypeScript
     needs: [resolve]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-ts.yaml
     with:
       release_tag: ${{ needs.resolve.outputs.release_tag }}

--- a/scripts/ci/ts.sh
+++ b/scripts/ci/ts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Publish TypeScript protobuf types to npm registry via pnpm.
+# Publish TypeScript protobuf types to npm registry via npm (OIDC trusted publishing).
 #
 # Usage: ts.sh [--dry-run] <version>
 #
@@ -65,10 +65,10 @@ cd dist
 node -e "const p=require('./package.json');p.version='$VERSION';delete p.scripts;require('fs').writeFileSync('./package.json',JSON.stringify(p,null,2))"
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "DRY_RUN: would run pnpm publish $PROVENANCE_FLAG --access public --tag $TAG"
-  pnpm pack
+  echo "DRY_RUN: would run npm publish $PROVENANCE_FLAG --access public --tag $TAG"
+  npm pack
 else
-  pnpm publish $PROVENANCE_FLAG --access public --tag "$TAG" --no-git-checks --verbose
+  npm publish $PROVENANCE_FLAG --access public --tag "$TAG"
 fi
 
 echo "Published @burnt-labs/xion-types@$VERSION (tag=$TAG)"

--- a/scripts/ci/ts.sh
+++ b/scripts/ci/ts.sh
@@ -53,11 +53,6 @@ else
 fi
 echo "dist-tag: $TAG"
 
-PROVENANCE_FLAG=""
-if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
-  PROVENANCE_FLAG="--provenance"
-fi
-
 # Publish from dist/ (where the compiled output lives)
 cd dist
 
@@ -65,10 +60,10 @@ cd dist
 node -e "const p=require('./package.json');p.version='$VERSION';delete p.scripts;require('fs').writeFileSync('./package.json',JSON.stringify(p,null,2))"
 
 if [[ "$DRY_RUN" == "true" ]]; then
-  echo "DRY_RUN: would run npm publish $PROVENANCE_FLAG --access public --tag $TAG"
+  echo "DRY_RUN: would run npm publish --access public --tag $TAG"
   npm pack
 else
-  npm publish $PROVENANCE_FLAG --access public --tag "$TAG"
+  npm publish --access public --tag "$TAG"
 fi
 
 echo "Published @burnt-labs/xion-types@$VERSION (tag=$TAG)"


### PR DESCRIPTION
## Problem

`Publish TypeScript to NPM` fails with `npm error code EOTP` — npm demands a 2FA one-time password on publish, which CI can't provide.

Root cause: `@burnt-labs/xion-types` has **"Require 2FA and disallow bypass-2FA tokens"** enabled, but the workflow authenticates with the `NPM_TOKEN` secret (a 2FA-bypass token), which npm now rejects. A **Trusted Publisher (OIDC)** is already registered on npm for this package (entry-point workflow `publish.yaml`) — the workflow just wasn't using it. This switches TS publishing to OIDC, the same mechanism xion.js uses.

## Changes

- **`publish-ts.yaml`**: drop `NODE_AUTH_TOKEN` and `registry-url` (they force the token path), and add a step to upgrade npm to `>= 11.5.1` (OIDC trusted publishing requires it; runs fine on the existing node 20).
- **`publish.yaml`**: grant `id-token: write` to the `publish-ts` caller job so the reusable workflow can mint the OIDC token.
- **`scripts/ci/ts.sh`**: publish with `npm publish --provenance` instead of `pnpm publish` (pnpm 9 doesn't do npm OIDC trusted publishing). The pnpm version-stamp / install / build steps are untouched.

## Notes

- No npm token needed after this; the trusted publisher authorizes `publish.yaml`.
- Only the publish path changes — node version and the build are unchanged, so no build-behavior risk.
- Verifiable once merged and a release is cut (OIDC only exchanges in a real GitHub-triggered run).
