### PR TITLE
chore: drop buf.build/burnt-labs/abstractaccount proto source

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,9 +99,8 @@ Sources are loaded from `scripts/proto-sources.conf` in order:
 2. buf.build/cosmos/ibc
 3. buf.build/cosmwasm/wasmd
 4. buf.build/cosmos/cosmos-sdk
-5. buf.build/burnt-labs/abstractaccount
-6. buf.build/burnt-labs/tokenfactory
-7. **buf.build/burnt-labs/xion (MUST BE LAST - overwrites shared imports)**
+5. buf.build/burnt-labs/tokenfactory
+6. **buf.build/burnt-labs/xion (MUST BE LAST - overwrites shared imports)**
 
 ## Development Workflows
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Sources are pulled from BSR at generation time — no git submodules required. C
 - `buf.build/cosmos/ibc`
 - `buf.build/cosmwasm/wasmd`
 - `buf.build/cosmos/cosmos-sdk`
-- `buf.build/burnt-labs/abstractaccount`
 - `buf.build/burnt-labs/tokenfactory`
 - `buf.build/burnt-labs/xion` *(pinnable via `BSR_MODULE` / `XION_BSR_MODULE`)*
 

--- a/scripts/proto-sources.conf
+++ b/scripts/proto-sources.conf
@@ -9,6 +9,5 @@ https://github.com/cosmos/ibc-apps.git#subdir=middleware/packet-forward-middlewa
 buf.build/cosmos/ibc
 buf.build/cosmwasm/wasmd
 buf.build/cosmos/cosmos-sdk
-buf.build/burnt-labs/abstractaccount
 buf.build/burnt-labs/tokenfactory
 buf.build/burnt-labs/xion


### PR DESCRIPTION
## What

Removes `buf.build/burnt-labs/abstractaccount` from `scripts/proto-sources.conf` (and the source lists in README / copilot-instructions).

## Why

The abstract-account module is being vendored into the xion repository as `x/abstractaccount` (burnt-labs/xion `work/2xburnt/vendor-abstract-account-20260819T204900Z`, targeted for v31). Its protos move to `proto/abstractaccount/v1` in xion under the **same** `abstractaccount.v1` package, so after v31 the `buf.build/burnt-labs/xion` module carries them itself and the standalone abstractaccount BSR module goes stale.

Generated output is unaffected: the proto package name is unchanged, and the xion source is loaded last ("last wins"), so it already takes precedence over the standalone module for identical paths.

## ⚠️ Do not merge before xion v31 is released

Until the xion release syncs `abstractaccount/v1` into `buf.build/burnt-labs/xion`, dropping the standalone source would remove those types from generation entirely.

Pre-merge check:

```sh
buf ls-files buf.build/burnt-labs/xion | grep abstractaccount
```

should list `abstractaccount/v1/*.proto`.